### PR TITLE
Use rootModuleName from metadata while unbundling

### DIFF
--- a/packages/savefile/src/main/unbundle.ts
+++ b/packages/savefile/src/main/unbundle.ts
@@ -40,7 +40,7 @@ const unbundleLuaScript = (object: TTSObject) => {
         script = script.replace(/(-- Bundled by luabundle {[^}]+})\s*\n/, "$1\n");
 
         const unbundled = unbundleString(script, { rootOnly: true });
-        return unbundled.modules.__root.content;
+        return unbundled.modules[unbundled.metadata.rootModuleName].content;
       }
 
       return script;


### PR DESCRIPTION
Updated the default name of the unbundle root module to match the one specified in the metadata.

Here's where you can find the source code where Benjamin implemented this: [unbundle/index.ts#L51](https://github.com/Benjamin-Dobell/luabundle/blob/e62a5125c65d089ec63633a70997279fca42b99e/src/unbundle/index.ts#L51)

I've also included [a test file](https://pastebin.com/6YUxQ2nX) for your reference, when objects are loaded it would throw an error and the Script.ttslua for Global would not be created.

Here's the error in question:
```
Error during extracting script for object undefined-undefined TypeError: Cannot read properties of undefined (reading 'content')
	at unbundleLuaScript....
```