### PR TITLE
Added option to use multiple paths, refactored XMLBundle logic

### DIFF
--- a/packages/savefile/src/main/bundle.ts
+++ b/packages/savefile/src/main/bundle.ts
@@ -5,6 +5,8 @@ import { bundleString } from "luabundle";
 import { Options } from "./embed";
 import { SaveFile, TTSObject } from "./model/tts";
 
+import { join as pathJoin } from "path";
+
 /**
  * Creates a copy of the given save file and bundles all Lua/XML scripts with the given options.
  */
@@ -19,29 +21,35 @@ export const bundleObject = (object: TTSObject, options: Options) => {
   return cloneDeepWith(object, bundler(options));
 };
 
-const bundler = (options: Options) => {
-  return (value: any, key: string | number | undefined, obj: any) => {
-    if (key === "LuaScript" && value) {
-      return luaBundle(obj.LuaScript, options.includePath);
-    } else if (key == "XmlUI" && value) {
-      return bundleXml(value, options.includePath);
-    }
-
-    return undefined;
-  };
+/**
+ * Function factory to be used with cloneDeepWith to bundle Lua and XML scripts.
+ *
+ * @param options The options object.
+ * @returns The cuztomizer function for cloneDeepWith.
+ */
+const bundler = (options: Options) => (value: any, key: string | number | undefined, obj: any) => {
+  if (!value) return undefined;
+  if (key === "LuaScript") {
+    return luaBundle(obj.LuaScript, options.includePaths, options.luaPatterns);
+  } else if (key == "XmlUI") {
+    return bundleXml(value, options.includePaths);
+  }
 };
 
 /**
- * Bundles the given Lua `script` by resolving `require()` calls using the given `includePath`.
+ * Bundles the given Lua `script` by resolving `require()` calls using the given `includePaths`.
  *
  * @param script The script content.
- * @param includePath The path to look for additional includes.
+ * @param includePaths The path array to look for additional includes.
  * @returns The bundled script.
  */
-const luaBundle = (script: string, includePath: string): string => {
-  const bundled = bundleString(script, {
-    paths: [`${includePath}/?.lua`, `${includePath}/?.ttslua`],
-  });
-
+const luaBundle = (script: string, includePaths: string[], luaPatterns?: string[]): string => {
+  // Default patterns to look for Lua files, can be overridden by the user
+  luaPatterns = luaPatterns ?? ['?.lua', '?.ttslua'];
+  // Combine both arrays to create a list of paths to look for includes
+  const paths = luaPatterns.flatMap(pt => includePaths.map(p => pathJoin(p, pt)));
+  // Also add the patterns directly to account for absolute paths
+  paths.push(...luaPatterns);
+  const bundled = bundleString(script, { paths });
   return bundled.startsWith("-- Bundled") ? bundled + "\n" : bundled;
 };

--- a/packages/savefile/src/main/embed.ts
+++ b/packages/savefile/src/main/embed.ts
@@ -8,14 +8,18 @@ import { SaveFile, TTSObject } from "./model/tts";
  */
 export interface Options {
   /** The path where the scripts and XML files will be included from. */
-  includePath: string;
+  includePaths: string[];
   metadataField?: string;
+
+  /** File extension for scripts */
+  scriptExtension?: "ttslua" | "lua";
+  luaPatterns?: string[];
 }
 
 export const readExtractedSave = (path: string, options: Options) => {
   const saveFile = readData(path, options) as SaveFile;
 
-  saveFile.LuaScript = readScript(path);
+  saveFile.LuaScript = readScript(path, options);
   saveFile.LuaScriptState = readScriptState(path);
   saveFile.XmlUI = readUi(path);
   saveFile.ObjectStates = readContents(path, options) ?? [];
@@ -41,7 +45,7 @@ const readData = (path: string, options: Options) => {
 
 const readObject = (path: string, options: Options): TTSObject => {
   const data = readData(path, options) as TTSObject;
-  data.LuaScript = readScript(path);
+  data.LuaScript = readScript(path, options);
   data.LuaScriptState = readScriptState(path);
   data.XmlUI = readUi(path);
 
@@ -91,8 +95,9 @@ const readChildObjects = (path: string, options: Options): TTSObject[] | undefin
   return children.map((e) => readObject(`${path}/${e.path}`, options));
 };
 
-const readScript = (path: string): string => {
-  return readFile(path, "Script.ttslua");
+const readScript = (path: string, options: Options): string => {
+  const ext = options.scriptExtension || "ttslua";
+  return readFile(path, `Script.${ext}`);
 };
 
 const readScriptState = (path: string): string => {

--- a/packages/savefile/src/main/extract.ts
+++ b/packages/savefile/src/main/extract.ts
@@ -35,6 +35,9 @@ export interface Options {
   statesPath?: string;
   childrenPath?: string;
   keyOrder?: string[];
+
+  /** File extension for scripts */
+  scriptExtension?: "ttslua" | "lua";
 }
 
 const state = {
@@ -101,7 +104,8 @@ const extractObject = (object: TTSObject, path: string, options: Options) => {
 
 const extractScripts = (object: TTSObject | SaveFile, path: string, options: Options) => {
   if (object.LuaScript) {
-    writeFile(`${path}/Script.ttslua`, object.LuaScript);
+    const ext = options.scriptExtension || "ttslua";
+    writeFile(`${path}/Script.${ext}`, object.LuaScript);
   }
 
   if (object.LuaScriptState && options.withState) {

--- a/packages/xmlbundle/src/xmlbundle.ts
+++ b/packages/xmlbundle/src/xmlbundle.ts
@@ -1,73 +1,63 @@
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
+import { isAbsolute as pathIsAbsolute, join as pathJoin } from "path";
+
+enum FileState {
+  Unresolved,
+  Resolving,
+  Resolved,
+}
 
 const INCLUDE_REGEX = /^([\t ]*)<Include src=(["'])(.+)\2\s*\/>/im;
 const BORDER_REGEX = /(<!-- include (.*?) -->)(.*?)\1/gs;
+const wrapBorder = (label: string, content: string) => `<!-- include ${label} -->\n${content}\n<!-- include ${label} -->`;
 
-export const bundle = (xmlUi: string, includePath: string): string => {
-  return resolve(xmlUi, includePath, [], true);
-};
+export const unbundle = (xmlUi: string): string => xmlUi.replaceAll(BORDER_REGEX, '<Include src="$2" />');
+export const bundle = (xmlUi: string, includePaths: string[]): string => new Solver(includePaths).bundle(xmlUi);
 
-export const unbundle = (xmlUi: string): string => {
-  const replacement = '<Include src="$2" />';
+class Solver {
+  // Define include paths as attr so we can access them everywhere without passing them around
+  constructor(private readonly includePaths: string[]) {}
 
-  return xmlUi.replaceAll(BORDER_REGEX, replacement);
-};
+  // Use a record to keep track of file states and avoid pass-by-reference issues with arrays / sets
+  public bundle(input: string, fileRecords: Record<string, FileState> = {}): string {
+    let match = input.match(INCLUDE_REGEX);
+    while (match) {
+      // Array destructuring to get the match groups
+      const [matchContent, indent, _, file] = match;
+      const resolvedPath = this.resolvePath(file);
+      if (resolvedPath === undefined)
+        throw new Error(`File not found: ${file}`);
+      if (resolvedPath in fileRecords && fileRecords[resolvedPath] === FileState.Resolving)
+        throw new Error(`Cycle detected! File was already included before: ${resolvedPath}`);
 
-const resolve = (xmlUi: string, path: string, alreadyResolved: string[], topLevel: boolean) => {
-  let resolved = xmlUi;
-  let match = resolved.match(INCLUDE_REGEX);
-
-  while (match) {
-    let resolvedInclude = readInclude(match[3], path, alreadyResolved);
-    if (topLevel) {
-      alreadyResolved = [];
+      // Read the file content and add it to the records
+      const includeContent = readFileSync(resolvedPath, { encoding: "utf-8" });
+      fileRecords[resolvedPath] = FileState.Resolving;
+      // Recursively call the bundle method to resolve nested includes, preserving indentation
+      const bundledInclude = this.bundle(includeContent, fileRecords)
+        .replace(/^(?=.)/gm, indent);
+      fileRecords[resolvedPath] = FileState.Resolved;
+      // Replace the include tag with the bundled content
+      const start = match.index!;
+      const end = start + matchContent.length;
+      input = input.substring(0, start) + wrapBorder(file, bundledInclude) + input.substring(end);
+      match = input.match(INCLUDE_REGEX);
     }
 
-    const indent = match[1] ?? "";
-    resolvedInclude = resolvedInclude
-      .split("\n")
-      .map((line) => (line ? indent + line : line))
-      .join("\n");
-
-    const start = match.index!;
-    const end = start + match[0].length;
-
-    resolved = resolved.substring(0, start) + resolvedInclude + resolved.substring(end);
-    match = resolved.match(INCLUDE_REGEX);
+    return input;
   }
 
-  return resolved;
-};
-
-const getFilePath = (fileName: string): { subPath: string; fileName: string } => {
-  fileName = fileName.toLowerCase();
-  if (!fileName.endsWith(".xml")) {
-    fileName += ".xml";
+  private resolvePath(file: string): string | undefined {
+    file = file.toLowerCase();
+    file = file.endsWith(".xml") ? file : file + ".xml";
+    // Account for absolute paths
+    if (pathIsAbsolute(file) && existsSync(file)) return file;
+    else {
+      // If not, check if the file exists in any of the include paths, the first one found will be used
+      for (const currentPath of this.includePaths) {
+        const candidate = pathJoin(currentPath, file)
+        if(existsSync(candidate)) return candidate;
+      }
+    }
   }
-
-  let filePath: any = fileName.match(/(.+)\//);
-  if (filePath) {
-    filePath = "/" + filePath[1];
-  } else {
-    filePath = "";
-  }
-
-  return { subPath: filePath, fileName: fileName };
-};
-
-const readInclude = (file: string, currentPath: string, alreadyResolved: string[]) => {
-  const { subPath, fileName } = getFilePath(file);
-  const border = `<!-- include ${file} -->`;
-  const filePath = `${currentPath}/${fileName}`;
-
-  if (alreadyResolved.includes(filePath)) {
-    throw new Error(`Cycle detected! File "${filePath}" was already included before.`);
-  }
-
-  alreadyResolved.push(filePath);
-
-  const includeContent = readFileSync(filePath, { encoding: "utf-8" });
-  const resolved = resolve(includeContent, currentPath + subPath, alreadyResolved, false);
-
-  return `${border}\n${resolved}\n${border}`;
-};
+}


### PR DESCRIPTION
LuaBundle allows the option for [multiple search paths](https://github.com/Benjamin-Dobell/luabundle?tab=readme-ov-file#search-paths), this PR exposes this feature to `embedSave` and consistently uses the same search paths for XML.

While looking into XML bundling logic I performed some refactoring which solves edge cases when detecting include cycles. 
Given the following directed graph, where each node represents the XMLUI string, and arrows the include operation:

<img src="https://github.com/Sebaestschjin/tts-tools/assets/8442693/c9daa9e6-c8cd-4c75-b034-79e2b7df14d4" width="400">

The red test should fail since a cycle is introduced, but the green test should succeed because no cycles are introduced, on current version the green test also fails because the [`alreadyResolved`](https://github.com/Sebaestschjin/tts-tools/blob/f673377b12a5cac871d9499759f95cf1f9d39ed8/packages/xmlbundle/src/xmlbundle.ts#L63) variable is only reset at top level. Javascript would pass variables by value and allow for local scope modification without impacting the recursion stack, but for arrays and object types it does this by reference, hence the need to reset it when top level is reached, while it solves the issue at top level, nested includes are impacted by this.

![fail-test](https://github.com/Sebaestschjin/tts-tools/assets/8442693/003bc15f-856c-4b80-9d88-71f9e4f88a83)

This can be improved without relying on pass-by-value behavior like shallow copies, by [using a record](https://github.com/rolandostar/tts-tools/blob/77200a10cc94f7da9c547cefdb189cc9a1dc2e05/packages/xmlbundle/src/xmlbundle.ts#L35) to distinguish between of nodes which have been fully explored and still being explored (AKA "grey" nodes in Depth-First Search)

Here's a test [fixture](https://github.com/Sebaestschjin/tts-tools/files/14271441/fixture.zip) replicating the diagram which I used to test the new logic.

All that'd be needed is for the Global.xml to read
```
<Include src="1" />
```

This PR also adds the capacity for using absolute paths in XML Bundling.

```
<Include src="C:\Users\Rolando\Documents\Tabletop Simulator\abs.xml" />
```

Indentation was also preserved, same as current ([screenshot](https://github.com/Sebaestschjin/tts-tools/assets/8442693/93febc2f-87c6-4f3d-aa94-52679fe7bdf9))

Also added a simple option to specify which extension to use when writing scripts to disk (between, `.ttslua` and `.lua`) since some vscode extensions, particularly language servers are triggered based on filename extension, this would allow to use one or the other and let users make use of additional features based on Lua's extensions.