### PR TITLE
Negated Regex Logic for directory names

### DIFF
--- a/packages/savefile/src/main/extract.ts
+++ b/packages/savefile/src/main/extract.ts
@@ -219,8 +219,8 @@ const keyOrderer = (a: Element, b: Element, keyOrder: string[]) => {
 };
 
 const getDirectoryName = (object: TTSObject): string => {
-  let objectPath = (object.Nickname || object.Name) + "." + object.GUID;
-  return objectPath.replace(/[/\\?%*:|"<>]/g, "-");
+  return `${object.Nickname.length > 0 ? object.Nickname : object.Name}.${object.GUID}`
+    .replace(/[^\w \^&'@{}\[\],$=!\-#()%\.+~_]/g, "-");
 };
 
 const getFreeDirectoryName = (object: TTSObject, path: string): string => {


### PR DESCRIPTION
Instead of searching for non-allowed characters, we negate allowed characters. The amount of non-allowed characters is much larger (Think of unicode, control characters, non-printables)

A practical example is someone editing Data.json for the Nickname to include a newline (\n), which renders correctly in-game but current version is unable to retrieve scripts since the folder location cannot be created.

![image](https://github.com/Sebaestschjin/tts-tools/assets/8442693/a24e66b7-dfc2-4672-8d44-fea7a0c709d7)

Other characteristics such as Reserved direcotry names (CON, PRN...) don't apply since we append the GUID, 
And other rules (starting ending in space or dot) seem apply to filenames only, testing reveals directories are correctly created in these cases.

I've also explicitly stated the condition for Nickname to be OR'd, according to https://typescript-eslint.io/rules/strict-boolean-expressions/